### PR TITLE
Adding 2022 Vision Blackout Rules

### DIFF
--- a/2022/2022-ssl-vision-blackout-rules.adoc
+++ b/2022/2022-ssl-vision-blackout-rules.adoc
@@ -1,0 +1,27 @@
+
+:imagesdir: images/
+
+= RoboCup 2022 SSL Vision Blackout Technical Challenge Rules
+{docdate}
+:toc:
+:sectnumlevels: 0
+
+// add icons from fontawesome in a up-to-date version
+ifdef::basebackend-html[]
+++++
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
+++++
+endif::basebackend-html[]
+
+:icons: font
+:numbered:
+
+NOTE: References to the male gender in the rules with respect to referees, team members, officials, etc. are for simplification and apply to both males and females.
+
+include::chapters/introduction.adoc[]
+
+include::chapters/hardware.adoc[]
+
+include::chapters/procedure.adoc[]
+
+include::chapters/scoring.adoc[]

--- a/2022/chapters/hardware.adoc
+++ b/2022/chapters/hardware.adoc
@@ -1,0 +1,32 @@
+== Hardware/Software Requirements
+
+=== Robot Hardware
+
+While we encourage participants to attempt the use of their blackout
+solutions during main competition to help deal with noise and dropouts
+in the global vision system, we recognize that integration into the
+main competition robots is a difficult task. For these reasons, the
+hardware restrictions are relaxed for this technical challenge.
+
+Teams may still remotely control their robots during normal
+competition, however, we encourage teams to experiment with onboard
+processing and autonomy. Regardless of where the control software
+executes, team will not receive data from the SSL vision
+software. Teams will still receive start, stop, and halt ref commands
+which will be used to initiate and stop trials of each stage.
+
+All robot hardware requirements apply to this challenge **EXCEPT** the height
+restrictions and the pattern markings. Participant robots may be taller than the
+rules dictate. The vision pattern on-top of the robot *MUST* be covered or
+removed to guarantee that ssl-vision is not being utilized. However, other rules
+such as maximum speed, kick power, ball manipulation strategies, etc. must still
+be observed.
+
+There are no restrictions on onboard sensor types. External sensors
+not attached to the robot are not allowed for this competition. We
+encourage teams to be creative in their choice of sensors and their
+strategies for completing each stage of the challenge. There is no
+restriction on processing power or where the processing takes
+place. However, keep in mind that bandwidth at competition is limited,
+so solutions requiring streaming large amounts of data wirelessly will
+likely not work.

--- a/2022/chapters/introduction.adoc
+++ b/2022/chapters/introduction.adoc
@@ -32,9 +32,8 @@ The competition will consist of five stages:
 
 1. Grab a stationary ball somewhere on the field
 2. Score with the ball on an empty goal
-3. Score with the ball on a statically defended goal
-4. Move the robot to specific coordinates
-5. Score an indirect goal (two robots needed)
+3. Move the robot to specific coordinates
+4. Score an indirect goal (two robots needed)
 
 Stage 1 is designed to demonstrate basic sensing and locomotion
 capabilities of each participating team.
@@ -42,14 +41,10 @@ capabilities of each participating team.
 Stage 2 is designed to demonstrate similar skills to stage 1 plus the
 ability to localize and aim at a known target on the field.
 
-Stage 3 builds on stage 2 where now the participant's robot must
-detect which portion of the goal is unblocked when aiming and
-shooting.
+Stage 3 demonstrates strong localization abilities without the use of 
+the global vision system.
 
-Stage 4 demonstrates ball manipulation skills and strong localization
-abilities without the use of the global vision system.
-
-Stage 5 is designed to demonstrate coordination skill of multiple robots
+Stage 4 is designed to demonstrate coordination skill of multiple robots
 without vision. The robots must colaborate to pass and score the goal.
 
 We believe that teams who can complete even a single one of these

--- a/2022/chapters/introduction.adoc
+++ b/2022/chapters/introduction.adoc
@@ -1,0 +1,62 @@
+== Goals of the Technical Challenge
+
+The goal of this technical challenge is to incentivize teams to
+explore local sensing and processing rather than the typical SSL
+approach of an off-board computer and a global set of cameras sensing
+the environment. While the main league still uses the standard SSL
+vision software with overhead cameras, there is desire to reduce the
+reliance on this vision system. We believe that not only will more
+distributed sensing and processing on robots help advance research in
+this league, it will provide a benefit to teams who take this
+approach.
+
+Overall, this technical challenge will focus on demonstrating standard
+SSL soccer skills (e.g. locomotion, ball manipulation and colaboration 
+between robots) in without the ssl-vision software running. The challenge
+is split into multiple stages designed to have different levels of difficulty,
+with each stage building on the skills of the prior.
+
+=== Participation Requirements
+
+Anyone participating in SSL RoboCup is eligible to participate in this
+challenge. Anyone participating must publish their approach to solving
+this technical challenege after the competition has concluded. The
+goal of forcing publication is that other participants in the league
+and the wider research community can learn and benefit from those that
+participated. Teams are also encouraged to present their approach in the
+poster sessions.
+
+=== Overview of Competition Stages
+
+The competition will consist of five stages:
+
+1. Grab a stationary ball somewhere on the field
+2. Score with the ball on an empty goal
+3. Score with the ball on a statically defended goal
+4. Move the robot to specific coordinates
+5. Score an indirect goal (two robots needed)
+
+Stage 1 is designed to demonstrate basic sensing and locomotion
+capabilities of each participating team.
+
+Stage 2 is designed to demonstrate similar skills to stage 1 plus the
+ability to localize and aim at a known target on the field.
+
+Stage 3 builds on stage 2 where now the participant's robot must
+detect which portion of the goal is unblocked when aiming and
+shooting.
+
+Stage 4 demonstrates ball manipulation skills and strong localization
+abilities without the use of the global vision system.
+
+Stage 5 is designed to demonstrate coordination skill of multiple robots
+without vision. The robots must colaborate to pass and score the goal.
+
+We believe that teams who can complete even a single one of these
+skills without the vision system information will have an advantage in
+the main competition over those teams who rely solely on the global
+vision system.
+
+The following sections describe the hardware requirements, and
+procedures of each stage. The final chapter describes overall scoring
+that will be used to determine the winner.

--- a/2022/chapters/introduction.adoc
+++ b/2022/chapters/introduction.adoc
@@ -28,7 +28,7 @@ poster sessions.
 
 === Overview of Competition Stages
 
-The competition will consist of five stages:
+The competition will consist of four stages:
 
 1. Grab a stationary ball somewhere on the field
 2. Score with the ball on an empty goal

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -1,6 +1,6 @@
 == Competition Procedure
 
-Each stage will consist of 3 independent trial run by each
+Each stage will consist of 3 independent trials run by each
 participant. This is to account for any random effects as well as to
 allow participants to adjust in-between their trials. Scoring will be
 based on overall performance among the trials for each stage, so it is
@@ -17,7 +17,7 @@ that teams have similar time to prepare before the challenge, all
 participants in that stage will compete at the same time. Participants
 who are unable to complete a trial for technical reasons will receive
 no points for that trial, but if the technical issues have been
-resolved before their next trial(s) they will be allowed to continue
+resolved before their next trial(s), they will be allowed to continue
 participating.
 
 Challenges will be executed on a Division B sized field as described
@@ -26,16 +26,16 @@ in the main SSL rules.
 Because the vision patterns are not required, markings may be added to the field
 before a run to help the human judges verify that the robots are reaching the
 desired positions and orientations. Teams should not expect a perfect field with
-no additional markings, however, attempts will be made to keep the marks minimal
+no additional markings. However, attempts will be made to keep the marks minimal
 and small so as to not interfere with on-board vision solutions. Additionally,
-teams should expect visual aspects of the field to vary slightly including exact
-color of the carpet and walls, width of line markings, etc.
+teams should expect visual aspects of the field to vary slightly, including the exact
+color of the carpet and walls, the width of line markings, etc.
 
-Each run will start with a halt command. Just before the start a stop command
+Each run will start with a halt command. Just before the start, a stop command
 will be given, but the robot should not move during the stop command. This is
 just to allow teams a few seconds to initialize any internal state. The run will
 officially start when a force start command is sent. This will start the timer
-and at this point the robot may begin moving.
+, and at this point, the robot may begin moving.
 
 === Stage 1: Grab a Stationary Ball
 
@@ -44,16 +44,16 @@ and control capabilities. The robot will need to detect a ball on the
 field, navigate to it, and place it on its dribbler. Partial points
 will be awarded, and time will be used for tie-breaking.
 
-For each trial a random robot starting location/orientation and a
+For each trial, a random robot starting location/orientation and a
 random ball starting position will be chosen. Both the robot and the
 ball will start stationary. There are no restrictions on the starting
 configuration other than that both robot and ball will be somewhere on
 the field.
 
-Before each run the robot will begin in the halt state. A stop command
+Before each run, the robot will begin in the halt state. A stop command
 will be issued to ready the robot, but the robot should not yet
-move. The run begins with a force start command at which point the
-timer starts and the robot may attempt to complete the task.
+move. The run starts with a force start command, at which point the
+timer starts, and the robot may attempt to complete the task.
 
 The robot may move anywhere on the field within the walls. The ball
 may similarly move anywhere on the field throughout the time. Each
@@ -63,15 +63,15 @@ trial will last a maximum of one minute.
 
 - Touching the ball with any part of the robot -- +1
 - Touching the ball with the dribbler -- +1
-- Robot stopped with ball touching dribbler at the end of the run :: +1
+- Robot stopped with the ball touching the dribbler at the end of the run-- +1
 
 In the event of a tie between participants for this trial shorter
-times will be used to determine ordering.
+times will be used to determine the ordering.
 
 === Stage 2: Scoring on an Empty Goal
 
 This stage is designed to build on stage 1, requiring that participant
-robot's can also detect/localize on a goal without the SSL vision
+robots can also detect/localize on a goal without the SSL vision
 software. Like stage 1, the robot will need to detect a ball, move to
 it and manipulate it. The robot must put the ball into the goal to
 receive maximum points in the trial.
@@ -79,12 +79,12 @@ receive maximum points in the trial.
 The robot and ball will start the same as in Stage 1. This time, the
 goal is for the robot to score on an empty goal. Either goal on the
 field is acceptable. While scoring the robot may not enter the defense
-zone. Unlike regular gameplay the ball does not need to stay on the
+zone. Unlike regular gameplay, the ball does not need to stay on the
 ground in order for the goal to be counted.
 
 Before each run the robot will begin in the halt state. A stop command
 will be issued to ready the robot, but the robot should not yet
-move. The run begins with a force start command at which point the
+move. The run begins with a force start command, at which point the
 timer starts and the robot may attempt to complete the task. Each
 trial will last a maximum of one minute. The trial will stop when the
 goal has occurred or time has elapsed.
@@ -103,45 +103,48 @@ This stage is designed to demonstrate localization capabilities
 without the use of the global vision system. No ball will be used for
 this stage.
 
-Robots will start at a random location/orientation somewhere on the field.
-Coordinates/angle will be manually provided to the teams before a run so that
-they can seed their location tracker with an estimate of the starting
-configuration. A destination position will be manually given to the teams at the
+Robots will start at a random location/orientation somewhere on the field. And teams
+will receive an area of start (not a precise coordinate) before a run, so they 
+can seed their location tracker with an estimate of the starting configuration.
+A destination position will be manually given to the teams at the
 start of the trial. The robots must drive to that position within the time
 limits. Final orientation does not matter. Teams can enter the initial location
 and goal position however they want (e.g. typing in numbers to a config before
-running, a GUI for clicking approximate location on the field, etc.).
+running, a GUI for clicking an approximate location on the field, etc.). 
+After the team enters the initial config, the robot will be randomly placed
+in the given area.
 
-Before each run the robot will begin in the halt state. A stop command
+Before each run, the robot will begin in the halt state. A stop command
 will be issued to ready the robot, but the robot should not yet
-move. The run begins with a force start command at which point the
+move. The run begins with a force start command, at which point the
 timer starts and the robot may attempt to complete the task.
 
-Robots have 1 minute to reach their the defined location. The trial
+Robots have 1 minute to reach the defined location. The trial
 will end when the robot has stopped for 10 seconds (after having moved
-at least once since the trial start) or time has elapsed. The 10
-second stoppage will be subtracted from the total time used to
+at least once since the trial start) or the time has elapsed. The 10
+seconds stoppage will be subtracted from the total time used to
 determine tie-breaking.
 
 ==== Scoring
 
 Score is equal to the negative straight line distance between the
-robot's final position and the destination position. In otherwords,
+robot's final position and the destination position. In other words,
 closer is better.
 
-=== Stage 4: Scoring an Indirect Goal
+=== Stage 4: Scoring an Indirect Goal (without Obstacles)
 
-This stage is a more complex version of stage 3 and 4. The goal is the same,
-but now robot must pass the ball to a second robot. Like stage 2, a specific 
-goal will be designated so the receiver robot can attempt to score on the goal.
+This stage is a more complex version of stage 2 and 3. The objective is the same,
+but now robot must pass the ball to a second robot. Different from stage 2, the
+robots should score a goal on the positive side of the field.
 
-The goal is to be able to use local sensing to recognize ally and opponent robots
-in a game like scenario, and pass and receive ball without external sensors.
+The objective is collaborate using sensors to recognize ally robots in a game like
+scenario, and pass and receive the ball without external sensors.
 
-The passing robot and ball will start the same as in Stage 2. The receiver
-robot will start at a random position in opposite quadrant (at X axis) of 
-passing robot. The target goal will be on the same half that the robot starts on. 
-While scoring any robot may not enter the defense zone.
+One robot will start at a position (0.5m, 1.5m) and another in (0.5m, -1.5m), both
+orientations will be at 0. The ball position will start at the rambom position in the 
+positive side of the field. To maintain the difficulty, the robot distance from
+one of the robots will be equal between different teams. While scoring, the robots 
+may not enter the defense zone.
 
 ==== Scoring
 

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -122,6 +122,7 @@ Robots are required to recognize other robots, receive a ball, coordinate betwee
 - Touching the ball with the passing robot dribbler -- +1
 - Pass hits receiver robot -- +1
 - Pass hits the receiver robot dribbler -- +1
-- Ball entered any defense zone -- +1
-- Ball entered any goal -- +1
+- If shot by receiver robot:
+    - Ball entered any defense zone -- +1
+    - Ball entered any goal -- +1
 - Robot entered any defense zone -- -1

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -104,7 +104,7 @@ without the use of the global vision system. No ball will be used for
 this stage.
 
 Robots will start at a random location/orientation somewhere on the field. And teams
-will receive an area of start (not a precise coordinate) before a run, so they 
+will receive an start area of 1m² before a run (not a precise coordinate), so they 
 can seed their location tracker with an estimate of the starting configuration.
 A destination position will be manually given to the teams at the
 start of the trial. The robots must drive to that position within the time

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -1,63 +1,53 @@
 == Competition Procedure
 
-Each stage will consist of 3 independent trials run by each
-participant. This is to account for any random effects as well as to
-allow participants to adjust in-between their trials. Scoring will be
-based on overall performance among the trials for each stage, so it is
-important for teams to perform consistently well.
+There are multiple stages with increasing difficulty.
+Participants will have 3 trials for each stage.
+All trials will be considered for the overall score.
 
-While the particular starting configurations of the ball and the robot
-will be different between stages and trial to trial, the TC member
-running the competition stage will strive to make the starting
-conditions similar between each participant for that trial run.
+Each trial will be attempted by all participants, who after another.
+The starting configuration of the trial will be similar for each team to achieve same conditions for all participants.
 
-Each stage will be run independently, although scheduling constraints
-may force each stage to be run back-to-back. In order to make sure
-that teams have similar time to prepare before the challenge, all
-participants in that stage will compete at the same time. Participants
-who are unable to complete a trial for technical reasons will receive
-no points for that trial, but if the technical issues have been
-resolved before their next trial(s), they will be allowed to continue
-participating.
+If a participant can not attempt a trial for what ever reasons, no points are awarded for this trial.
+Other trials are not effected.
 
-Challenges will be executed on a Division B sized field as described
-in the main SSL rules.
+The robots may move anywhere on the field within the walls.
+The ball may similarly move anywhere on the field throughout the time.
+Any defined positions will always be inside the field boundaries.
 
-Because the vision patterns are not required, markings may be added to the field
-before a run to help the human judges verify that the robots are reaching the
-desired positions and orientations. Teams should not expect a perfect field with
-no additional markings. However, attempts will be made to keep the marks minimal
-and small so as to not interfere with on-board vision solutions. Additionally,
-teams should expect visual aspects of the field to vary slightly, including the exact
-color of the carpet and walls, the width of line markings, etc.
+=== Field setup
 
-Each run will start with a halt command. Just before the start, a stop command
-will be given, but the robot should not move during the stop command. This is
-just to allow teams a few seconds to initialize any internal state. The run will
-officially start when a force start command is sent. This will start the timer
-, and at this point, the robot may begin moving.
+Challenges will be executed on a Division B sized field as described in the main SSL rules.
+
+Because the vision patterns are not required, markings may be added to the field before a run to help the human judges verify that the robots are reaching the desired positions and orientations.
+Participants should not expect a perfect field with no additional markings.
+However, attempts will be made to keep the marks minimal and small to not interfere with on-board vision solutions.
+Additionally, participants should expect visual aspects of the field to vary slightly, including the exact color of the carpet and walls, the width of line markings, etc.
+
+=== Referee commands
+
+Each trial will start with a *HALT* command.
+Just before the start, a *STOP* command will be given to allow participants to prepare.
+When a *FORCE START* command is sent the timer is started and robots may move.
+The trial will be stopped with a *HALT* command, when it was successful or time run out.
+
+=== Scoring
+
+Stage may define a set of criteria that give positive or negative points.
+Points will also be given if the overall objective was not achieved.
+The duration of the trial is used as a tie-breaker (faster is better).
 
 === Stage 1: Grab a Stationary Ball
 
-This stage is designed to be the easiest and demonstrate basic sensing
-and control capabilities. The robot will need to detect a ball on the
-field, navigate to it, and place it on its dribbler. Partial points
-will be awarded, and time will be used for tie-breaking.
+This stage is designed to be the easiest and demonstrate basic sensing and control capabilities.
+The robot will need to detect a ball on the field, navigate to it, and place it on its dribbler.
 
-For each trial, a random robot starting location/orientation and a
-random ball starting position will be chosen. Both the robot and the
-ball will start stationary. There are no restrictions on the starting
-configuration other than that both robot and ball will be somewhere on
-the field.
+==== Procedure
 
-Before each run, the robot will begin in the halt state. A stop command
-will be issued to ready the robot, but the robot should not yet
-move. The run starts with a force start command, at which point the
-timer starts, and the robot may attempt to complete the task.
-
-The robot may move anywhere on the field within the walls. The ball
-may similarly move anywhere on the field throughout the time. Each
-trial will last a maximum of one minute.
+- The supervisor defines a random robot starting position and orientation
+- The supervisor defines a random ball starting position
+- Robot and ball are moved to their starting positions
+- The trial is started
+- The trial is stopped after one minute or if the robot did not move for 10 seconds after moving at least once
 
 ==== Scoring
 
@@ -65,86 +55,62 @@ trial will last a maximum of one minute.
 - Touching the ball with the dribbler -- +1
 - Robot stopped with the ball touching the dribbler at the end of the run-- +1
 
-In the event of a tie between participants for this trial shorter
-times will be used to determine the ordering.
-
 === Stage 2: Scoring on an Empty Goal
 
-This stage is designed to build on stage 1, requiring that participant
-robots can also detect/localize on a goal without the SSL vision
-software. Like stage 1, the robot will need to detect a ball, move to
-it and manipulate it. The robot must put the ball into the goal to
-receive maximum points in the trial.
+This stage requires that robots can localize a goal and itself The robot will need to detect the ball, move to it and score a goal.
 
-The robot and ball will start the same as in Stage 1. This time, the
-goal is for the robot to score on an empty goal. Either goal on the
-field is acceptable. While scoring the robot may not enter the defense
-zone. Unlike regular gameplay, the ball does not need to stay on the
-ground in order for the goal to be counted.
+==== Procedure
 
-Before each run the robot will begin in the halt state. A stop command
-will be issued to ready the robot, but the robot should not yet
-move. The run begins with a force start command, at which point the
-timer starts and the robot may attempt to complete the task. Each
-trial will last a maximum of one minute. The trial will stop when the
-goal has occurred or time has elapsed.
+- The supervisor defines a random robot starting position and orientation
+- The supervisor defines a random ball starting position
+- Robot and ball are moved to their starting positions
+- The trial is started
+- The trial is stopped after one minute or if the robot scored a goal
+
+==== Additional Rules
+
+- Either of the two goals can be used for scoring
 
 ==== Scoring
 
 - Touching the ball with any part of the robot -- +1
 - Touching the ball with the dribbler -- +1
-- Ball entered defense zone -- +1
-- Ball entered goal -- +1
-- Robot entered defense zone -- -1
+- Ball entered any defense zone -- +1
+- Ball entered any goal -- +1
+- Robot entered any defense zone -- -1
 
-=== Stage 3: Moving to specific coordinates
+=== Stage 3: Moving to Specific Coordinates
 
-This stage is designed to demonstrate localization capabilities
-without the use of the global vision system. No ball will be used for
-this stage.
+This stage is designed to demonstrate localization capabilities without the use of the global vision system.
+No ball will be used for this stage.
 
-Robots will start at a random location/orientation somewhere on the field. And teams
-will receive an start area of 1m² before a run (not a precise coordinate), so they 
-can seed their location tracker with an estimate of the starting configuration.
-A destination position will be manually given to the teams at the
-start of the trial. The robots must drive to that position within the time
-limits. Final orientation does not matter. Teams can enter the initial location
-and goal position however they want (e.g. typing in numbers to a config before
-running, a GUI for clicking an approximate location on the field, etc.). 
-After the team enters the initial config, the robot will be randomly placed
-in the given area.
+==== Procedure
 
-Before each run, the robot will begin in the halt state. A stop command
-will be issued to ready the robot, but the robot should not yet
-move. The run begins with a force start command, at which point the
-timer starts and the robot may attempt to complete the task.
-
-Robots have 1 minute to reach the defined location. The trial
-will end when the robot has stopped for 10 seconds (after having moved
-at least once since the trial start) or the time has elapsed. The 10
-seconds stoppage will be subtracted from the total time used to
-determine tie-breaking.
+- The supervisor defines a random robot target position
+- The supervisor defines a random robot starting position seed
+- Participants may enter the staring position seed and the target position into their robot configuration
+- The supervisor defines a random robot starting orientation
+- The supervisor defines a random robot starting position that is within 0.5 m distance to the position seed
+- the Robot is moved to its starting positions and orientation
+- The trial is started
+- The trial is stopped after one minute or if the robot did not move for 10 seconds after moving at least once
 
 ==== Scoring
 
-Score is equal to the negative straight line distance between the
-robot's final position and the destination position. In other words,
-closer is better.
+Score is equal to the negative straight line distance between the robot's final position and the destination position.
+In other words, closer is better.
 
 === Stage 4: Scoring an Indirect Goal (without Obstacles)
 
-This stage is a more complex version of stage 2 and 3. The objective is the same,
-but now robot must pass the ball to a second robot. Different from stage 2, the
-robots should score a goal on the positive side of the field.
+The objective of this stage is to score an indirect goal using two robots.
+Robots are required to recognize other robots, receive a ball and coordinate between each other.
 
-The objective is collaborate using sensors to recognize ally robots in a game like
-scenario, and pass and receive the ball without external sensors.
+==== Procedure
 
-One robot will start at a position (0.5m, 1.5m) and another in (0.5m, -1.5m), both
-orientations will be at 0. The ball position will start at the rambom position in the 
-positive side of the field. To maintain the difficulty, the robot distance from
-one of the robots will be equal between different teams. While scoring, the robots 
-may not enter the defense zone.
+- The supervisor defines a random ball starting position seed in the positive field half
+- Robot 1 is placed at (0.5 m, 1.5 m, 0°)
+- Robot 2 is placed at (0.5 m, 1.5 m, 0°)
+- The ball is placed at a random ball starting position that is within 0.5 m distance to the position seed
 
 ==== Scoring
 

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -107,7 +107,7 @@ Robots are required to recognize other robots, receive a ball, coordinate betwee
 
 - The supervisor defines a random ball starting position seed in the positive field half
 - Robot 1 is placed at (0.5 m, 1.5 m, 0°)
-- Robot 2 is placed at (0.5 m, 1.5 m, 0°)
+- Robot 2 is placed at (0.5 m, -1.5 m, 0°)
 - The ball is placed at a random starting position within 0.5 m distance of the position seed.
 
 ==== Scoring

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -164,10 +164,10 @@ statically defended goal.
 The obstacle will be a black cylindrical and of the approximate
 dimensions of a typical SSL robot. The goal is to be able to use local
 sensing to recognize ally and opponent robots in a game like scenario, and 
-also pass and receive ball withou external sensors.
+also pass and receive ball without external sensors.
 
 The passing robot and ball will start the same as in Stage 3. The receiver
-robot will start at a random position in opposite quarant (at X axis) of 
+robot will start at a random position in opposite quadrant (at X axis) of 
 passing robot. The target goal will be on the same half that the robot starts on. 
 While scoring the receiver robot may not enter the defense zone. This time the 
 ball must enter the goal via a flat kick to prevent kicking over the obstacle.
@@ -175,7 +175,6 @@ ball must enter the goal via a flat kick to prevent kicking over the obstacle.
 ==== Scoring
 
 - Touching the ball with any part of the passing robot -- +1
-- Touching the ball with the passing robot dribbler -- +1
 - Touching the ball with the passing robot dribbler -- +1
 - Pass hits receiver robot -- +1
 - Pass hits enemy robot -- -1

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -97,32 +97,7 @@ goal has occurred or time has elapsed.
 - Ball entered goal -- +1
 - Robot entered defense zone -- -1
 
-=== Stage 3: Scoring on a Statically Defended Goal
-
-This stage is a more complex version of stage 2. The goal is the same,
-but now there will be a static obstacle placed somewhere inside the
-defense zone. Unlike stage 2, a specific goal will be designated so
-that robots can attempt to score on the statically defended goal.
-
-The obstacle will be approximately cylindrical and of the approximate
-dimensions of a typical SSL robot. The goal is to be able to use local
-sensing to detect opponent robots in a game like scenario.
-
-The robot and ball will start the same as in Stage 1 and Stage
-2. Unlike Stage 2, robots must only score in the designated goal. The target
-goal will be on the same half that the robot starts on. While scoring the robot
-may not enter the defense zone. This time the ball must enter the goal via a
-flat kick to prevent kicking over the obstacle.
-
-==== Scoring
-
-- Touching the ball with any part of the robot -- +1
-- Touching the ball with the dribbler -- +1
-- Ball entered defense zone -- +1
-- Ball entered goal -- +1
-- Robot entered defense zone -- -1
-
-=== Stage 4: Moving to specific coordinates
+=== Stage 3: Moving to specific coordinates
 
 This stage is designed to demonstrate localization capabilities
 without the use of the global vision system. No ball will be used for
@@ -154,30 +129,28 @@ Score is equal to the negative straight line distance between the
 robot's final position and the destination position. In otherwords,
 closer is better.
 
-=== Stage 5: Scoring an Indirect Goal
+=== Stage 4: Scoring an Indirect Goal
 
 This stage is a more complex version of stage 3 and 4. The goal is the same,
-but now robot must pass the ball to a second robot. Like stage 3, a specific 
-goal will be designated so the receiver robot can attempt to score on the 
-statically defended goal.
+but now robot must pass the ball to a second robot. Like stage 2, a specific 
+goal will be designated so the receiver robot can attempt to score on the goal.
 
-The obstacle will be a black cylindrical and of the approximate
-dimensions of a typical SSL robot. The goal is to be able to use local
-sensing to recognize ally and opponent robots in a game like scenario, and 
-also pass and receive ball without external sensors.
+The goal is to be able to use local sensing to recognize ally and opponent robots
+in a game like scenario, and pass and receive ball without external sensors.
 
-The passing robot and ball will start the same as in Stage 3. The receiver
+The passing robot and ball will start the same as in Stage 2. The receiver
 robot will start at a random position in opposite quadrant (at X axis) of 
 passing robot. The target goal will be on the same half that the robot starts on. 
-While scoring the receiver robot may not enter the defense zone. This time the 
-ball must enter the goal via a flat kick to prevent kicking over the obstacle.
+While scoring any robot may not enter the defense zone.
+
+Optionally, in any trial a team may choose to put a obstable in the middle of the 
+scoring goal, and in that case the goal points will be duplicated.
 
 ==== Scoring
 
 - Touching the ball with any part of the passing robot -- +1
 - Touching the ball with the passing robot dribbler -- +1
 - Pass hits receiver robot -- +1
-- Pass hits enemy robot -- -1
 - Pass hits the receiver robot dribbler -- +1
 - Ball entered defense zone -- +1
 - Ball entered goal -- +1

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -1,0 +1,185 @@
+== Competition Procedure
+
+Each stage will consist of 3 independent trial run by each
+participant. This is to account for any random effects as well as to
+allow participants to adjust in-between their trials. Scoring will be
+based on overall performance among the trials for each stage, so it is
+important for teams to perform consistently well.
+
+While the particular starting configurations of the ball and the robot
+will be different between stages and trial to trial, the TC member
+running the competition stage will strive to make the starting
+conditions similar between each participant for that trial run.
+
+Each stage will be run independently, although scheduling constraints
+may force each stage to be run back-to-back. In order to make sure
+that teams have similar time to prepare before the challenge, all
+participants in that stage will compete at the same time. Participants
+who are unable to complete a trial for technical reasons will receive
+no points for that trial, but if the technical issues have been
+resolved before their next trial(s) they will be allowed to continue
+participating.
+
+Challenges will be executed on a Division B sized field as described
+in the main SSL rules.
+
+Because the vision patterns are not required, markings may be added to the field
+before a run to help the human judges verify that the robots are reaching the
+desired positions and orientations. Teams should not expect a perfect field with
+no additional markings, however, attempts will be made to keep the marks minimal
+and small so as to not interfere with on-board vision solutions. Additionally,
+teams should expect visual aspects of the field to vary slightly including exact
+color of the carpet and walls, width of line markings, etc.
+
+Each run will start with a halt command. Just before the start a stop command
+will be given, but the robot should not move during the stop command. This is
+just to allow teams a few seconds to initialize any internal state. The run will
+officially start when a force start command is sent. This will start the timer
+and at this point the robot may begin moving.
+
+=== Stage 1: Grab a Stationary Ball
+
+This stage is designed to be the easiest and demonstrate basic sensing
+and control capabilities. The robot will need to detect a ball on the
+field, navigate to it, and place it on its dribbler. Partial points
+will be awarded, and time will be used for tie-breaking.
+
+For each trial a random robot starting location/orientation and a
+random ball starting position will be chosen. Both the robot and the
+ball will start stationary. There are no restrictions on the starting
+configuration other than that both robot and ball will be somewhere on
+the field.
+
+Before each run the robot will begin in the halt state. A stop command
+will be issued to ready the robot, but the robot should not yet
+move. The run begins with a force start command at which point the
+timer starts and the robot may attempt to complete the task.
+
+The robot may move anywhere on the field within the walls. The ball
+may similarly move anywhere on the field throughout the time. Each
+trial will last a maximum of one minute.
+
+==== Scoring
+
+- Touching the ball with any part of the robot -- +1
+- Touching the ball with the dribbler -- +1
+- Robot stopped with ball touching dribbler at the end of the run :: +1
+
+In the event of a tie between participants for this trial shorter
+times will be used to determine ordering.
+
+=== Stage 2: Scoring on an Empty Goal
+
+This stage is designed to build on stage 1, requiring that participant
+robot's can also detect/localize on a goal without the SSL vision
+software. Like stage 1, the robot will need to detect a ball, move to
+it and manipulate it. The robot must put the ball into the goal to
+receive maximum points in the trial.
+
+The robot and ball will start the same as in Stage 1. This time, the
+goal is for the robot to score on an empty goal. Either goal on the
+field is acceptable. While scoring the robot may not enter the defense
+zone. Unlike regular gameplay the ball does not need to stay on the
+ground in order for the goal to be counted.
+
+Before each run the robot will begin in the halt state. A stop command
+will be issued to ready the robot, but the robot should not yet
+move. The run begins with a force start command at which point the
+timer starts and the robot may attempt to complete the task. Each
+trial will last a maximum of one minute. The trial will stop when the
+goal has occurred or time has elapsed.
+
+==== Scoring
+
+- Touching the ball with any part of the robot -- +1
+- Touching the ball with the dribbler -- +1
+- Ball entered defense zone -- +1
+- Ball entered goal -- +1
+- Robot entered defense zone -- -1
+
+=== Stage 3: Scoring on a Statically Defended Goal
+
+This stage is a more complex version of stage 2. The goal is the same,
+but now there will be a static obstacle placed somewhere inside the
+defense zone. Unlike stage 2, a specific goal will be designated so
+that robots can attempt to score on the statically defended goal.
+
+The obstacle will be approximately cylindrical and of the approximate
+dimensions of a typical SSL robot. The goal is to be able to use local
+sensing to detect opponent robots in a game like scenario.
+
+The robot and ball will start the same as in Stage 1 and Stage
+2. Unlike Stage 2, robots must only score in the designated goal. The target
+goal will be on the same half that the robot starts on. While scoring the robot
+may not enter the defense zone. This time the ball must enter the goal via a
+flat kick to prevent kicking over the obstacle.
+
+==== Scoring
+
+- Touching the ball with any part of the robot -- +1
+- Touching the ball with the dribbler -- +1
+- Ball entered defense zone -- +1
+- Ball entered goal -- +1
+- Robot entered defense zone -- -1
+
+=== Stage 4: Moving to specific coordinates
+
+This stage is designed to demonstrate localization capabilities
+without the use of the global vision system. No ball will be used for
+this stage.
+
+Robots will start at a random location/orientation somewhere on the field.
+Coordinates/angle will be manually provided to the teams before a run so that
+they can seed their location tracker with an estimate of the starting
+configuration. A destination position will be manually given to the teams at the
+start of the trial. The robots must drive to that position within the time
+limits. Final orientation does not matter. Teams can enter the initial location
+and goal position however they want (e.g. typing in numbers to a config before
+running, a GUI for clicking approximate location on the field, etc.).
+
+Before each run the robot will begin in the halt state. A stop command
+will be issued to ready the robot, but the robot should not yet
+move. The run begins with a force start command at which point the
+timer starts and the robot may attempt to complete the task.
+
+Robots have 1 minute to reach their the defined location. The trial
+will end when the robot has stopped for 10 seconds (after having moved
+at least once since the trial start) or time has elapsed. The 10
+second stoppage will be subtracted from the total time used to
+determine tie-breaking.
+
+==== Scoring
+
+Score is equal to the negative straight line distance between the
+robot's final position and the destination position. In otherwords,
+closer is better.
+
+=== Stage 5: Scoring an Indirect Goal
+
+This stage is a more complex version of stage 3 and 4. The goal is the same,
+but now robot must pass the ball to a second robot. Like stage 3, a specific 
+goal will be designated so the receiver robot can attempt to score on the 
+statically defended goal.
+
+The obstacle will be a black cylindrical and of the approximate
+dimensions of a typical SSL robot. The goal is to be able to use local
+sensing to recognize ally and opponent robots in a game like scenario, and 
+also pass and receive ball withou external sensors.
+
+The passing robot and ball will start the same as in Stage 3. The receiver
+robot will start at a random position in opposite quarant (at X axis) of 
+passing robot. The target goal will be on the same half that the robot starts on. 
+While scoring the receiver robot may not enter the defense zone. This time the 
+ball must enter the goal via a flat kick to prevent kicking over the obstacle.
+
+==== Scoring
+
+- Touching the ball with any part of the passing robot -- +1
+- Touching the ball with the passing robot dribbler -- +1
+- Touching the ball with the passing robot dribbler -- +1
+- Pass hits receiver robot -- +1
+- Pass hits enemy robot -- -1
+- Pass hits the receiver robot dribbler -- +1
+- Ball entered defense zone -- +1
+- Ball entered goal -- +1
+- Robot entered defense zone -- -1

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -89,7 +89,7 @@ No ball will be used for this stage.
 - Participants may enter the staring position seed and the target position into their robot configuration
 - The supervisor defines a random robot starting orientation
 - The supervisor defines a random robot starting position that is within 0.5 m distance to the position seed
-- the Robot is moved to its starting positions and orientation
+- The robot is moved to its starting position and orientation.
 - The trial is started
 - The trial is stopped after one minute or if the robot did not move for 10 seconds after moving at least once
 

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -4,14 +4,14 @@ There are multiple stages with increasing difficulty.
 Participants will have 3 trials for each stage.
 All trials will be considered for the overall score.
 
-Each trial will be attempted by all participants, who after another.
+Each trial will be attempted by all participants, one after another.
 The starting configuration of the trial will be similar for each team to achieve same conditions for all participants.
 
 If a participant can not attempt a trial for what ever reasons, no points are awarded for this trial.
 Other trials are not effected.
 
 The robots may move anywhere on the field within the walls.
-The ball may similarly move anywhere on the field throughout the time.
+Similarly, the ball may move anywhere on the field throughout the time.
 Any defined positions will always be inside the field boundaries.
 
 === Field setup
@@ -27,24 +27,23 @@ Additionally, participants should expect visual aspects of the field to vary sli
 
 Each trial will start with a *HALT* command.
 Just before the start, a *STOP* command will be given to allow participants to prepare.
-When a *FORCE START* command is sent the timer is started and robots may move.
-The trial will be stopped with a *HALT* command, when it was successful or time run out.
+When a *FORCE START* command is sent, the timer is started and robots may move.
+The trial will be stopped with a *HALT* command after successful challenge completion or after the time ran out
 
 === Scoring
 
-Stage may define a set of criteria that give positive or negative points.
+Each stage may define a set of criteria which give positive or negative points.
 Points will also be given if the overall objective was not achieved.
-The duration of the trial is used as a tie-breaker (faster is better).
+The duration of a trial is used as a tie-breaker (faster is better).
 
 === Stage 1: Grab a Stationary Ball
 
-This stage is designed to be the easiest and demonstrate basic sensing and control capabilities.
+This stage is designed to be the easiest and to demonstrate basic sensing and control capabilities.
 The robot will need to detect a ball on the field, navigate to it, and place it on its dribbler.
 
 ==== Procedure
 
-- The supervisor defines a random robot starting position and orientation
-- The supervisor defines a random ball starting position
+- The supervisor defines random starting positions for robot and ball, as well as a random orientation for the robot.
 - Robot and ball are moved to their starting positions
 - The trial is started
 - The trial is stopped after one minute or if the robot did not move for 10 seconds after moving at least once
@@ -57,7 +56,7 @@ The robot will need to detect a ball on the field, navigate to it, and place it 
 
 === Stage 2: Scoring on an Empty Goal
 
-This stage requires that robots can localize a goal and itself The robot will need to detect the ball, move to it and score a goal.
+This stage requires robots to localize themselves as well as the ball on the playing field, move to the ball and score a goal.
 
 ==== Procedure
 
@@ -69,7 +68,7 @@ This stage requires that robots can localize a goal and itself The robot will ne
 
 ==== Additional Rules
 
-- Either of the two goals can be used for scoring
+- Either of the two goals may be used for scoring
 
 ==== Scoring
 
@@ -86,8 +85,7 @@ No ball will be used for this stage.
 
 ==== Procedure
 
-- The supervisor defines a random robot target position
-- The supervisor defines a random robot starting position seed
+- The supervisor defines a random target position, random robot orientation and a random start position seed.
 - Participants may enter the staring position seed and the target position into their robot configuration
 - The supervisor defines a random robot starting orientation
 - The supervisor defines a random robot starting position that is within 0.5 m distance to the position seed
@@ -97,20 +95,20 @@ No ball will be used for this stage.
 
 ==== Scoring
 
-Score is equal to the negative straight line distance between the robot's final position and the destination position.
-In other words, closer is better.
+The score is equal to the negative straight line distance between the robot's final position and the destination position.
+(In other words, closer is better)
 
 === Stage 4: Scoring an Indirect Goal (without Obstacles)
 
 The objective of this stage is to score an indirect goal using two robots.
-Robots are required to recognize other robots, receive a ball and coordinate between each other.
+Robots are required to recognize other robots, receive a ball, coordinate between each other and finally to score a goal.
 
 ==== Procedure
 
 - The supervisor defines a random ball starting position seed in the positive field half
 - Robot 1 is placed at (0.5 m, 1.5 m, 0°)
 - Robot 2 is placed at (0.5 m, 1.5 m, 0°)
-- The ball is placed at a random ball starting position that is within 0.5 m distance to the position seed
+- The ball is placed at a random starting position within 0.5 m distance of the position seed.
 
 ==== Scoring
 
@@ -118,6 +116,6 @@ Robots are required to recognize other robots, receive a ball and coordinate bet
 - Touching the ball with the passing robot dribbler -- +1
 - Pass hits receiver robot -- +1
 - Pass hits the receiver robot dribbler -- +1
-- Ball entered defense zone -- +1
+ - Ball entered a defense zone -- +1
 - Ball entered goal -- +1
-- Robot entered defense zone -- -1
+- Robot entered a defense zone -- -1

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -114,6 +114,7 @@ Robots are required to recognize other robots, receive a ball, coordinate betwee
 - Robot 2 is placed on starting position [0.5 m, -1.5 m, 0°]
 - The ball is placed on a random starting position within 0.5 m distance of the position seed.
 - The trial is started
+    * The first robot that touches the ball will be considered the passer, and the other, the receiver.
 - The trial is stopped after two minutes or if a robot scored a goal
 
 ==== Scoring
@@ -122,7 +123,7 @@ Robots are required to recognize other robots, receive a ball, coordinate betwee
 - Touching the ball with the passing robot dribbler -- +1
 - Pass hits receiver robot -- +1
 - Pass hits the receiver robot dribbler -- +1
-- If last touched by receiver robot:
+- If pass occurs (ball touched by both robots):
     * Ball entered any defense zone -- +1
     * Ball entered any goal -- +1
 - Robot entered any defense zone -- -1

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -123,7 +123,7 @@ Robots are required to recognize other robots, receive a ball, coordinate betwee
 - Touching the ball with the passing robot dribbler -- +1
 - Pass hits receiver robot -- +1
 - Pass hits the receiver robot dribbler -- +1
-- If pass occurs (ball touched by both robots):
+- If both robots have touched the ball:
     * Ball entered any defense zone -- +1
     * Ball entered any goal -- +1
 - Robot entered any defense zone -- -1

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -56,7 +56,7 @@ The robot will need to detect a ball on the field, navigate to it, and place it 
 
 === Stage 2: Scoring on an Empty Goal
 
-This stage requires robots to localize themselves as well as the ball on the playing field, move to the ball and score a goal.
+This stage requires robots to localize a goal as well as the ball on the playing field, move to the ball and score a goal.
 
 ==== Procedure
 

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -1,7 +1,8 @@
 == Competition Procedure
 
 There are multiple stages with increasing difficulty.
-Participants will have 3 trials for each stage.
+Each stage have three different situations.
+Participants will have only one trial per situation (three trials per stage).
 All trials will be considered for the overall score.
 
 Each trial will be attempted by all participants, one after another.
@@ -44,7 +45,7 @@ The robot will need to detect a ball on the field, navigate to it, and place it 
 ==== Procedure
 
 - The supervisor defines random starting positions for robot and ball, as well as a random orientation for the robot.
-- Robot and ball are moved to their starting positions
+- Robot and ball are placed on their starting positions
 - The trial is started
 - The trial is stopped after one minute or if the robot did not move for 10 seconds after moving at least once
 
@@ -62,7 +63,7 @@ This stage requires robots to localize a goal as well as the ball on the playing
 
 - The supervisor defines a random robot starting position and orientation
 - The supervisor defines a random ball starting position
-- Robot and ball are moved to their starting positions
+- Robot and ball are placed on their starting positions
 - The trial is started
 - The trial is stopped after one minute or if the robot scored a goal
 
@@ -85,11 +86,14 @@ No ball will be used for this stage.
 
 ==== Procedure
 
-- The supervisor defines a random target position, random robot orientation and a random start position seed.
-- Participants may enter the staring position seed and the target position into their robot configuration
+- The supervisor defines a
+* random robot target position (no specific orientation is required)
+* random robot starting orientation
+* random robot starting position seed
+- Participants may enter the starting position seed and the target position into their robot configuration
 - The supervisor defines a random robot starting orientation
 - The supervisor defines a random robot starting position that is within 0.5 m distance to the position seed
-- The robot is moved to its starting position and orientation.
+- The robot is placed on its starting position and turned to its starting orientation.
 - The trial is started
 - The trial is stopped after one minute or if the robot did not move for 10 seconds after moving at least once
 
@@ -105,10 +109,12 @@ Robots are required to recognize other robots, receive a ball, coordinate betwee
 
 ==== Procedure
 
-- The supervisor defines a random ball starting position seed in the positive field half
-- Robot 1 is placed at (0.5 m, 1.5 m, 0°)
-- Robot 2 is placed at (0.5 m, -1.5 m, 0°)
-- The ball is placed at a random starting position within 0.5 m distance of the position seed.
+- The supervisor defines a random ball starting position seed in the positive field half (positive x-coordinates)
+- Robot 1 is placed on starting position [0.5 m, 1.5 m, 0°]
+- Robot 2 is placed on starting position [0.5 m, -1.5 m, 0°]
+- The ball is placed on a random starting position within 0.5 m distance of the position seed.
+- The trial is started
+- The trial is stopped after two minutes or if a robot scored a goal
 
 ==== Scoring
 
@@ -116,6 +122,6 @@ Robots are required to recognize other robots, receive a ball, coordinate betwee
 - Touching the ball with the passing robot dribbler -- +1
 - Pass hits receiver robot -- +1
 - Pass hits the receiver robot dribbler -- +1
- - Ball entered a defense zone -- +1
-- Ball entered goal -- +1
-- Robot entered a defense zone -- -1
+- Ball entered any defense zone -- +1
+- Ball entered any goal -- +1
+- Robot entered any defense zone -- -1

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -143,9 +143,6 @@ robot will start at a random position in opposite quadrant (at X axis) of
 passing robot. The target goal will be on the same half that the robot starts on. 
 While scoring any robot may not enter the defense zone.
 
-Optionally, in any trial a team may choose to put a obstable in the middle of the 
-scoring goal, and in that case the goal points will be duplicated.
-
 ==== Scoring
 
 - Touching the ball with any part of the passing robot -- +1

--- a/2022/chapters/procedure.adoc
+++ b/2022/chapters/procedure.adoc
@@ -122,7 +122,7 @@ Robots are required to recognize other robots, receive a ball, coordinate betwee
 - Touching the ball with the passing robot dribbler -- +1
 - Pass hits receiver robot -- +1
 - Pass hits the receiver robot dribbler -- +1
-- If shot by receiver robot:
-    - Ball entered any defense zone -- +1
-    - Ball entered any goal -- +1
+- If last touched by receiver robot:
+    * Ball entered any defense zone -- +1
+    * Ball entered any goal -- +1
 - Robot entered any defense zone -- -1

--- a/2022/chapters/scoring.adoc
+++ b/2022/chapters/scoring.adoc
@@ -1,0 +1,16 @@
+== Overall Scoring
+
+As each stage is quite different in terms of scoring, in order to
+determine an overall winner, each stage will be ranked individually by
+total score. Depending on ranking in the category, each participant
+will get an amount of overall points. The amount of points is equal to
+the number of participants - placement in that stage. For example,
+with 7 participants, first place gets 6 points, second place gets 5,
+etc.
+
+Each of the stage points will then be totaled to determine an overall
+winner. Therefore, performance in all stages is considered equal in
+the final scoring.
+
+In the event of a tie, the team with the lowest total time across all
+the stages will win.


### PR DESCRIPTION
Adding Vision Blackout for 2022 RoboCup, main changes:
1. Adapt rules back to in real life competition. Setup will be communicated at RoboCup (no postions shared up-front).
2. Create a new scenario, with collaboration between robots to score an indirect goal.