### PR TITLE
Chip kick pass endurance challenge rules

### DIFF
--- a/2023/2023-ssl-chip-challenge-rules.adoc
+++ b/2023/2023-ssl-chip-challenge-rules.adoc
@@ -48,7 +48,7 @@ A pass is defined as follows:
 
 == Scoring
 
-A valid pass must meet the following constraints:
+A valid pass must meet the following criteria:
 
 * The pass distance must be at least *1.5m*.
 * The shooter of the previous pass can not be the receiver of the current pass (this implicitly means you need *at least 3 robots*).
@@ -56,10 +56,12 @@ A valid pass must meet the following constraints:
 * The ball must not exceed 6.5m/s (as defined in the tournament rules).
 * The source and target must be inside field lines.
 
+NOTE: Previous passes include all passes, not only those considered valid.
+
 Passes are scored as follows:
 
 * A valid ground pass -- *1 point*
-* A valid chip pass -- *3 points*
+* A valid chipped pass -- *3 points*
 
 Additionally, the following rules apply:
 

--- a/2023/2023-ssl-chip-challenge-rules.adoc
+++ b/2023/2023-ssl-chip-challenge-rules.adoc
@@ -1,0 +1,91 @@
+:source-highlighter: highlightjs
+
+= RoboCup 2023 SSL Chip Pass Challenge Rules
+{docdate}
+:toc:
+:sectnumlevels: 0
+
+// add icons from fontawesome in a up-to-date version
+ifdef::backend-html5[]
+++++
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous">
+++++
+endif::backend-html5[]
+
+:icons: font
+:numbered:
+
+NOTE: References to the male gender in the rules with respect to referees, team
+members, officials, etc. are for simplification and apply to both males and
+females.
+
+== Motivation
+
+A key distinguishing characteristic of the Small Size League is its tight integration of software and hardware, which is crucial to create a dynamic collaborative soccer match. The chip kick challenge goal is to develop the passing skill accuracy and endurance to enable more plays and increase ball posession time in the game.
+
+== Constraints
+
+- Challenges will be playable on the practice filed with Division B size.
+- Human interference is not allowed unless specified otherwise.
+- The filed boundaries needs to be respected.
+- Teams can use up to 6 robots.
+
+== Challenge: Chip kick pass endurance
+
+==== Objective
+
+For best results, a team must be able to kick and receive the ball precisely, fast, often, and withing filed lines. This is not only challenging for the software, but also for the mechanics of the robot.
+
+Within a 5 minutes, the team is asked to perform as many passes as possible, prefebly a chip kick pass, as it counts more than a ground pass. The team that performs the most passes wins.
+
+==== Procedure
+
+- The team places all robots on the middle line and the ball on the center point.
+- A FORCE_START command will be issued and the timer will start.
+- After *5min* a HALT command will be issued and the challenge is over.
+
+==== Rules
+
+Teams are free in how they perform the passes. Definitions of a pass in general and additional constrains for valid
+pass that are considered in the scoring are given in this section.
+
+A pass is defined as follows:
+
+- A pass has a source position, a target position and a shooter.
+- The source position is where the ball was kicked by a robot.
+- The target position is where the ball either stops or changes direction by more than 30 degrees.
+- The shooter is the robot located nearest to the source position when the pass started.
+- The pass distance is the euclidean distance between source and target position.
+- The pass direction is the orientation of the vector of `target - source`.
+
+For a chip kick pass, besides previous definition:
+
+- The ball needs to rech at least 15cm high to be considered a valid chip pass.
+
+A valid pass must additionally met the following constraints:
+
+- The pass distance must be at least *1.5m*.
+- The shooter of the previous pass can not be the receiver of the current pass (this implicitly means you need *at least 3 robots*).
+- The pass direction of the pass must differ by at least *10 degrees* from the inverted previous pass direction: latexmath:[abs(passDirection_{cur} - (passDirection_{previous} + 180°)) > 10°]
+- The ball must not exceed 6.5 m/s (as defined in the tournament rules).
+
+NOTE: Previous passes include all passes, not only those considered valid.
+
+Additionally, the following rules apply:
+
+- The number of robots is limited to *6 robots*.
+- Teams are allowed and encouraged to recover the ball from the field boundary.
+- Any human interference, including exchanging robots, reduces the final number of passes by *10*.
+- Whenever ball goes out of field lines, the number of passes is reduced by *1*.
+- If the ball is kicked out of the field, the ball can be positined inside filed. The repositioning will count as human interference.
+
+==== Evaluation
+
+The team with most valid passes wins. If teams have the same number of passes, they will share the better position.
+
+- One ground pass counts as 1 pass.
+- One chip kick pass counts as 3 passes.
+
+Two of more members of OC/TC will be assigned to each challenge and act as the referee. The referee has the final decision of the result. If the two referees counts differ, the final result will be the counts average.
+
+

--- a/2023/2023-ssl-chip-challenge-rules.adoc
+++ b/2023/2023-ssl-chip-challenge-rules.adoc
@@ -41,7 +41,7 @@ A pass is defined as follows:
 
 * A pass has a source position, a target position and a shooter.
 * The source position is where a robot kicks the ball.
-* The target position is where the ball stops or changes direction by more than *30 degrees*.
+* The target position is where the ball stops or changes direction by more than *30 degrees* in field plane (x, y).
 * The shooter is the robot located nearest to the source position when the pass starts.
 * The pass distance is the euclidean distance between the source and target position.
 * The pass direction is the orientation of the `target - source` vector.

--- a/2023/2023-ssl-chip-challenge-rules.adoc
+++ b/2023/2023-ssl-chip-challenge-rules.adoc
@@ -16,76 +16,59 @@ endif::backend-html5[]
 :numbered:
 
 NOTE: References to the male gender in the rules with respect to referees, team
-members, officials, etc. are for simplification and apply to both males and
+members, officials, etc., are for simplification and apply to both males and
 females.
 
-== Motivation
+== Goals of the Technical Challenge
 
-A key distinguishing characteristic of the Small Size League is its tight integration of software and hardware, which is crucial to create a dynamic collaborative soccer match. The chip kick challenge goal is to develop the passing skill accuracy and endurance to enable more plays and increase ball posession time in the game.
+A key distinguishing characteristic of the Small Size League is its tight integration of software and hardware, which is crucial to create a dynamic, collaborative soccer match. The chip kick challenge goal is to develop the passing skill accuracy and endurance to enable more plays and increase ball possession time in the game.
 
-== Constraints
+=== Participation Requirements
 
-- Challenges will be playable on the practice filed with Division B size.
-- Human interference is not allowed unless specified otherwise.
-- The filed boundaries needs to be respected.
-- Teams can use up to 6 robots.
+All teams are eligible and encouraged to participate in this challenge.
 
-== Challenge: Chip kick pass endurance
+== Procedure
 
-==== Objective
+* The team places its robots on the middle line and the ball on the center point.
+* A FORCE_START command will be issued, and the timer will start.
+* The team has *5min* to perform as many points as possible.
+* After *5min* a HALT command will be issued, and the challenge is over.
 
-For best results, a team must be able to kick and receive the ball precisely, fast, often, and withing filed lines. This is not only challenging for the software, but also for the mechanics of the robot.
+=== Pass Definitions
 
-Within a 5 minutes, the team is asked to perform as many passes as possible, prefebly a chip kick pass, as it counts more than a ground pass. The team that performs the most passes wins.
+Teams choose how they perform passes. However, a valid pass is defined as follows:
 
-==== Procedure
+* A pass has a source, target, and shooter position.
+* The source position is where a robot kicks the ball.
+* The target position is where the ball stops or changes direction by more than 30 degrees.
+* The shooter is the robot nearest the source position when the pass starts.
+* The pass distance is the euclidean distance between the source and target position.
+* The pass direction is the orientation of the `target - source` vector.
 
-- The team places all robots on the middle line and the ball on the center point.
-- A FORCE_START command will be issued and the timer will start.
-- After *5min* a HALT command will be issued and the challenge is over.
+For a valid chip kick pass, besides the previous definition:
 
-==== Rules
+* The ball must reach at least 15cm high to be considered a valid chip pass.
 
-Teams are free in how they perform the passes. Definitions of a pass in general and additional constrains for valid
-pass that are considered in the scoring are given in this section.
+== Evaluation
 
-A pass is defined as follows:
+The team with the most valid points wins. And the passes are evaluated as follows:
+* A ground pass -- +1 point
+* A chip pass -- +3 points
 
-- A pass has a source position, a target position and a shooter.
-- The source position is where the ball was kicked by a robot.
-- The target position is where the ball either stops or changes direction by more than 30 degrees.
-- The shooter is the robot located nearest to the source position when the pass started.
-- The pass distance is the euclidean distance between source and target position.
-- The pass direction is the orientation of the vector of `target - source`.
+Teams with the same number of points will share the better position. And two or more members of OC/TC will be assigned to each challenge and act as the referee. The referee has the final decision on the result. If the two referees' counts differ, the final result will be the points average.
 
-For a chip kick pass, besides previous definition:
+A valid pass must meet the following constraints:
 
-- The ball needs to rech at least 15cm high to be considered a valid chip pass.
+* The pass distance must be at least *1.5m*, from source to target.
+* The shooter of the previous pass can not be the receiver of the current pass (this implicitly means you need *at least 3 robots*).
+* The pass direction of the must differ by at least *10 degrees* from the inverted previous pass direction: latexmath:[abs(passDirection_{cur} - (passDirection_{previous} + 180°)) > 10°]
+* The ball must not exceed 6.5 m/s (as defined in the tournament rules).
+* The source and target should be inside field lines.
 
-A valid pass must additionally met the following constraints:
-
-- The pass distance must be at least *1.5m*.
-- The shooter of the previous pass can not be the receiver of the current pass (this implicitly means you need *at least 3 robots*).
-- The pass direction of the pass must differ by at least *10 degrees* from the inverted previous pass direction: latexmath:[abs(passDirection_{cur} - (passDirection_{previous} + 180°)) > 10°]
-- The ball must not exceed 6.5 m/s (as defined in the tournament rules).
-
-NOTE: Previous passes include all passes, not only those considered valid.
 
 Additionally, the following rules apply:
 
-- The number of robots is limited to *6 robots*.
-- Teams are allowed and encouraged to recover the ball from the field boundary.
-- Any human interference, including exchanging robots, reduces the final number of passes by *10*.
-- Whenever ball goes out of field lines, the number of passes is reduced by *1*.
-- If the ball is kicked out of the field, the ball can be positined inside filed. The repositioning will count as human interference.
-
-==== Evaluation
-
-The team with most valid passes wins. If teams have the same number of passes, they will share the better position.
-
-- One ground pass counts as 1 pass.
-- One chip kick pass counts as 3 passes.
-
-Two of more members of OC/TC will be assigned to each challenge and act as the referee. The referee has the final decision of the result. If the two referees counts differ, the final result will be the counts average.
-
-
+* The number of robots is limited to *6 robots*.
+* Teams are allowed and encouraged to recover the ball outside of field lines.
+* Any human interference, including exchanging robots, reduces the final number of points by *10*.
+* If the ball is kicked out of the field, the ball can be positioned inside. And it will count as human interference.

--- a/2023/2023-ssl-chip-challenge-rules.adoc
+++ b/2023/2023-ssl-chip-challenge-rules.adoc
@@ -19,56 +19,59 @@ NOTE: References to the male gender in the rules with respect to referees, team
 members, officials, etc., are for simplification and apply to both males and
 females.
 
-== Goals of the Technical Challenge
+== Goal
+A key distinguishing characteristic of the Small Size League is its tight integration of software and hardware, which is crucial to create a dynamic, collaborative soccer match.
 
-A key distinguishing characteristic of the Small Size League is its tight integration of software and hardware, which is crucial to create a dynamic, collaborative soccer match. The chip kick challenge goal is to develop the passing skill accuracy and endurance to enable more plays and increase ball possession time in the game.
+The task in this technical challenge is to perform as many passes between robots as possible within a limited amount of time, similar to the https://ssl.robocup.org/robocup-2021-challenges/[hardware challenge from 2021]. Additionally, teams are encouraged (but not forced) to chip kick the ball to show their ability to precisely perform and receive chipped passes.
 
-=== Participation Requirements
-
-All teams are eligible and encouraged to participate in this challenge.
+This challenge requires both, accurate passing skills and endurance. The robot hardware will be challenged with the high frequency of kicks. Still, the task is pretty straight forward and can be performed by any team with a bit of preparation. Thus, all teams are encouraged to participate.
 
 == Procedure
 
 * The team places its robots on the middle line and the ball on the center point.
 * A FORCE_START command will be issued, and the timer will start.
-* The team has *5min* to perform as many points as possible.
-* After *5min* a HALT command will be issued, and the challenge is over.
+* After *5min* a HALT command will be issued and the challenge is over.
 
 === Pass Definitions
 
-Teams choose how they perform passes. However, a valid pass is defined as follows:
+Teams are free in how they perform the passes. Definitions of a pass in general and additional constrains for valid pass that are considered in the scoring are given in this section.
 
-* A pass has a source, target, and shooter position.
+A pass is defined as follows:
+
+* A pass has a source position, a target position and a shooter.
 * The source position is where a robot kicks the ball.
-* The target position is where the ball stops or changes direction by more than 30 degrees.
-* The shooter is the robot nearest the source position when the pass starts.
+* The target position is where the ball stops or changes direction by more than *30 degrees*.
+* The shooter is the robot located nearest to the source position when the pass starts.
 * The pass distance is the euclidean distance between the source and target position.
 * The pass direction is the orientation of the `target - source` vector.
+* The pass is considered *chipped*, if the ball reached a maximum height of at least *15cm*.
 
-For a valid chip kick pass, besides the previous definition:
-
-* The ball must reach at least 15cm high to be considered a valid chip pass.
-
-== Evaluation
-
-The team with the most valid points wins. And the passes are evaluated as follows:
-* A ground pass -- +1 point
-* A chip pass -- +3 points
-
-Teams with the same number of points will share the better position. And two or more members of OC/TC will be assigned to each challenge and act as the referee. The referee has the final decision on the result. If the two referees' counts differ, the final result will be the points average.
+== Scoring
 
 A valid pass must meet the following constraints:
 
-* The pass distance must be at least *1.5m*, from source to target.
+* The pass distance must be at least *1.5m*.
 * The shooter of the previous pass can not be the receiver of the current pass (this implicitly means you need *at least 3 robots*).
-* The pass direction of the must differ by at least *10 degrees* from the inverted previous pass direction: latexmath:[abs(passDirection_{cur} - (passDirection_{previous} + 180°)) > 10°]
-* The ball must not exceed 6.5 m/s (as defined in the tournament rules).
-* The source and target should be inside field lines.
+* The pass direction of the pass must differ by at least *10 degrees* from the inverted previous pass direction: latexmath:[abs(passDirection_{cur} - (passDirection_{previous} + 180°)) > 10°]
+* The ball must not exceed 6.5m/s (as defined in the tournament rules).
+* The source and target must be inside field lines.
 
+Passes are scored as follows:
+
+* A valid ground pass -- *1 point*
+* A valid chip pass -- *3 points*
 
 Additionally, the following rules apply:
 
 * The number of robots is limited to *6 robots*.
 * Teams are allowed and encouraged to recover the ball outside of field lines.
-* Any human interference, including exchanging robots, reduces the final number of points by *10*.
-* If the ball is kicked out of the field, the ball can be positioned inside. And it will count as human interference.
+* Any human interference, including exchanging robots, reduces the final number of points by *10 points*.
+* If the ball is kicked out of the field, the ball can be positioned inside by the team. This will count as human interference.
+
+== Evaluation
+
+Two or more members of OC/TC will be assigned to each challenge and act as the referee. The referee has the final decision on the result. If the two referees' counts differ, the final result will be the points average.
+
+The team with the most points wins.
+The number of chipped passes acts as a tiebreaker.
+Teams with the same number of points and same number of chipped passes will share the better position.

--- a/2023/2023-ssl-chip-challenge-rules.adoc
+++ b/2023/2023-ssl-chip-challenge-rules.adoc
@@ -3,6 +3,7 @@
 = RoboCup 2023 SSL Chip Pass Challenge Rules
 {docdate}
 :toc:
+:stem: latexmath
 :sectnumlevels: 0
 
 // add icons from fontawesome in a up-to-date version


### PR DESCRIPTION
This PR adds the Chip Kick endurance challenge rules. Main changes from previous pass endurance (from 2021):
- Chip kick pass counts as 3 passes, and happens when ball reaches at least 15cm high.
- If ball goes outside of filed walls, the ball repositioning will count as human interference (reduces passes in 10).

The goal is to motivate for chip kick passing, and maintain ball possession within the field.