### PR TITLE
Update endurance pass challenge points to 5 for chipped pass

### DIFF
--- a/2023/2023-ssl-chip-challenge-rules.adoc
+++ b/2023/2023-ssl-chip-challenge-rules.adoc
@@ -62,7 +62,7 @@ NOTE: Previous passes include all passes, not only those considered valid.
 Passes are scored as follows:
 
 * A valid ground pass -- *1 point*
-* A valid chipped pass -- *3 points*
+* A valid chipped pass -- *5 points*
 
 Additionally, the following rules apply:
 


### PR DESCRIPTION
Due to Nicolai tests with robots, a chip pass takes 2 to 3 times more time. Therefore, to motivate for more chip, this PR increases chip points to 5.